### PR TITLE
Quick output fix

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -62,7 +62,7 @@ async function run() {
       return;
     }
 
-    console.log(`Found ref ${tagRef} as commit ${sha}`);
+    console.log(`Found ref ${tagRef || GITHUB_SHA} as commit ${sha}`);
 
     let ref;
     try {


### PR DESCRIPTION
Now that passing in a ref is optional, output the GITHUB_SHA in this case.  